### PR TITLE
Add Firebase waitlist API and frontend integration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -31,6 +31,10 @@
     ],
     "rewrites": [
       {
+        "source": "/api/**",
+        "function": "waitlist"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,93 +1,93 @@
-// /**
-//  * Import function triggers from their respective submodules:
-//  *
-//  * import {onCall} from "firebase-functions/v2/https";
-//  * import {onDocumentWritten} from "firebase-functions/v2/firestore";
-//  *
-//  * See a full list of supported triggers at https://firebase.google.com/docs/functions
-//  */
+import * as admin from 'firebase-admin';
+import { onRequest } from 'firebase-functions/v2/https';
+import * as logger from 'firebase-functions/logger';
 
-// import * as admin from "firebase-admin";
-// import {setGlobalOptions} from "firebase-functions";
-// import {onRequest} from "firebase-functions/https";
-// import * as logger from "firebase-functions/logger";
+// Initialize Firebase Admin SDK
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
 
-// // Initialize Firebase Admin SDK
-// if (!admin.apps.length) {
-//   admin.initializeApp();
-// }
+// Save emails to the "waitlist" collection while rate limiting by IP.
+export const waitlist = onRequest({ cors: true }, async (request, response) => {
+  // Only allow POST requests
+  if (request.method !== 'POST') {
+    response.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
 
-// // Start writing functions
-// // https://firebase.google.com/docs/functions/typescript
+  const { email } = request.body ?? {};
 
-// // For cost control, you can set the maximum number of containers that can be
-// // running at the same time. This helps mitigate the impact of unexpected
-// // traffic spikes by instead downgrading performance. This limit is a
-// // per-function limit. You can override the limit for each function using the
-// // `maxInstances` option in the function's options, e.g.
-// // `onRequest({ maxInstances: 5 }, (req, res) => { ... })`.
-// // NOTE: setGlobalOptions does not apply to functions using the v1 API. V1
-// // functions should each use functions.runWith({ maxInstances: 10 }) instead.
-// // In the v1 API, each function can only serve one request per container, so
-// // this will be the maximum concurrent request count.
-// setGlobalOptions({ maxInstances: 10 });
+  // Validate email
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    response.status(400).json({ error: 'Valid email is required' });
+    return;
+  }
 
-// // export const helloWorld = onRequest((request, response) => {
-// //   logger.info("Hello logs!", {structuredData: true});
-// //   response.send("Hello from Firebase!");
-// // });
+  const db = admin.firestore();
 
-// export const waitlist = onRequest(async (request, response) => {
-//   // Set CORS headers
-//   response.set('Access-Control-Allow-Origin', '*');
-//   response.set('Access-Control-Allow-Methods', 'GET, POST');
-//   response.set('Access-Control-Allow-Headers', 'Content-Type');
+  // Determine client IP address
+  const ipHeader =
+    (request.headers['x-forwarded-for'] as string | undefined) ||
+    request.ip ||
+    'unknown';
+  const clientIp = ipHeader.split(',')[0].trim();
 
-//   // Handle preflight requests
-//   if (request.method === 'OPTIONS') {
-//     response.status(204).send('');
-//     return;
-//   }
+  const ipDocRef = db
+    .collection('waitlist_ip_limits')
+    .doc(clientIp.replace(/[./#:]/g, '_'));
+  const now = admin.firestore.Timestamp.now();
+  const sixHoursAgo = admin.firestore.Timestamp.fromMillis(
+    now.toMillis() - 6 * 60 * 60 * 1000,
+  );
 
-//   // Only allow POST requests
-//   if (request.method !== 'POST') {
-//     response.status(405).json({ error: 'Method not allowed' });
-//     return;
-//   }
+  try {
+    await db.runTransaction(async (tx) => {
+      const ipDoc = await tx.get(ipDocRef);
+      let count = 0;
+      let firstTime = now;
+      if (ipDoc.exists) {
+        const data = ipDoc.data() as { count: number; firstRequestTime: admin.firestore.Timestamp };
+        firstTime = data.firstRequestTime;
+        if (firstTime.toMillis() < sixHoursAgo.toMillis()) {
+          count = 0;
+          firstTime = now;
+        } else {
+          count = data.count;
+        }
+      }
 
-//   try {
-//     const { email } = request.body;
+      if (count >= 2) {
+        throw new Error('Too many requests');
+      }
 
-//     // Validate email
-//     if (!email || typeof email !== 'string' || !email.includes('@')) {
-//       response.status(400).json({ error: 'Valid email is required' });
-//       return;
-//     }
+      tx.set(ipDocRef, { count: count + 1, firstRequestTime: firstTime });
+    });
+  } catch {
+    logger.warn(`Rate limit exceeded for IP ${clientIp}`);
+    response.status(429).json({ error: 'Too many requests from this IP. Try again later.' });
+    return;
+  }
 
-//     if (!admin.apps.length) {
-//       admin.initializeApp();
-//     }
-//     const db = admin.firestore();
+  try {
+    // Add email to waitlist collection
+    const docRef = await db.collection('waitlist').add({
+      email,
+      ip: clientIp,
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
-//     // Add email to waitlist collection
-//     const docRef = await db.collection('waitlist').add({
-//       email: email,
-//       timestamp: admin.firestore.FieldValue.serverTimestamp()
-//     });
+    logger.info(`Email added to waitlist: ${email}`, { structuredData: true });
 
-//     logger.info(`Email added to waitlist: ${email}`, { structuredData: true });
-    
-//     response.status(200).json({ 
-//       success: true, 
-//       message: 'Email added to waitlist successfully',
-//       id: docRef.id 
-//     });
-
-//   } catch (error) {
-//     logger.error('Error adding email to waitlist:', error);
-//     response.status(500).json({ 
-//       success: false, 
-//       error: 'Internal server error' 
-//     });
-//   }
-// });
+    response.status(200).json({
+      success: true,
+      message: 'Email added to waitlist successfully',
+      id: docRef.id,
+    });
+  } catch (error) {
+    logger.error('Error adding email to waitlist:', error);
+    response.status(500).json({
+      success: false,
+      error: 'Internal server error',
+    });
+  }
+});

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -9,38 +9,39 @@ import {
 } from '@mui/material';
 import { Bolt } from '@mui/icons-material';
 import EventAvailableIcon from '@mui/icons-material/EventAvailable';
-// import { useState } from 'react';
-// import { addEmailToWaitlist } from '../../services/waitlistService';
+import { useState } from 'react';
+import { addEmailToWaitlist } from '../../services/waitlistService';
 
 export const Landing = () => {
-  // TODO: Uncomment this when the waitlist is ready
-  // const [email, setEmail] = useState('');
-  // const [isLoading, setIsLoading] = useState(false);
-  // const [message, setMessage] = useState('');
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState('');
 
-  // const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   setEmail(event.target.value);
-  // };
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+  };
 
-  // const handleJoinWaitlist = async () => {
-  //   if (!email || !email.includes('@')) {
-  //     setMessage('Please enter a valid email address');
-  //     return;
-  //   }
+  const handleJoinWaitlist = async () => {
+    if (!email || !email.includes('@')) {
+      setMessage('Please enter a valid email address');
+      return;
+    }
 
-  //   setIsLoading(true);
-  //   setMessage('');
+    setIsLoading(true);
+    setMessage('');
 
-  //   try {
-  //     await addEmailToWaitlist(email);
-  //     setMessage('Successfully joined the waitlist!');
-  //     setEmail('');
-  //   } catch (error) {
-  //     setMessage(error instanceof Error ? error.message : 'Network error. Please try again.');
-  //   } finally {
-  //     setIsLoading(false);
-  //   }
-  // };
+    try {
+      await addEmailToWaitlist(email);
+      setMessage('Successfully joined the waitlist!');
+      setEmail('');
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : 'Network error. Please try again.',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   const teamMembers = [
     {
@@ -123,34 +124,30 @@ export const Landing = () => {
             label="Enter your email"
             variant="outlined"
             type="email"
-            // TODO: Uncomment this when the waitlist is ready
-            // value={email}
-            // onChange={handleEmailChange}
+            value={email}
+            onChange={handleEmailChange}
             fullWidth
             sx={{ minWidth: 300 }}
           />
-          <Button 
-            variant="contained" 
-            // TODO: Uncomment this when the waitlist is ready
-            // onClick={handleJoinWaitlist}
-            // disabled={isLoading}
+          <Button
+            variant="contained"
+            onClick={handleJoinWaitlist}
+            disabled={isLoading}
           >
-            {/* {isLoading ? 'Joining...' : 'Join'} */}
-            Join
+            {isLoading ? 'Joining...' : 'Join'}
           </Button>
         </Box>
-        {/* // TODO: Uncomment this when the waitlist is ready */}
-        {/* {message && (
-          <Typography 
-            variant="body2" 
-            sx={{ 
-              mt: 2, 
-              color: message.includes('Successfully') ? 'success.main' : 'error.main' 
+        {message && (
+          <Typography
+            variant="body2"
+            sx={{
+              mt: 2,
+              color: message.includes('Successfully') ? 'success.main' : 'error.main'
             }}
           >
             {message}
           </Typography>
-        )} */}
+        )}
       </Box>
 
       {/* About Us Section */}
@@ -559,20 +556,18 @@ export const Landing = () => {
             label="Enter your email"
             variant="outlined"
             type="email"
-            // TODO: Uncomment this when the waitlist is ready
-            // value={email}
-            // onChange={handleEmailChange}
+            value={email}
+            onChange={handleEmailChange}
             fullWidth
             sx={{ minWidth: 220 }}
           />
-          <Button 
-            variant="contained" 
-            size="large" 
-            // onClick={handleJoinWaitlist}
-            // disabled={isLoading}
+          <Button
+            variant="contained"
+            size="large"
+            onClick={handleJoinWaitlist}
+            disabled={isLoading}
           >
-            {/* {isLoading ? 'Joining...' : 'Join'} */}
-            Join
+            {isLoading ? 'Joining...' : 'Join'}
           </Button>
         </Box>
       </Box>

--- a/src/services/waitlistService.ts
+++ b/src/services/waitlistService.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+// Base URL for the waitlist API. When deployed to Firebase Hosting the
+// `/api` path is rewritten to the Cloud Function.
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
 export interface WaitlistResponse {
   success: boolean;


### PR DESCRIPTION
## Summary
- integrate waitlist form on landing page
- create Cloud Function to store emails in Firestore with IP rate limiting
- update waitlist service to call new API
- route `/api/*` URLs to the Cloud Function in `firebase.json`

## Testing
- `npm run lint`
- `npm run build`
- `npm --prefix functions run lint` *(fails: Invalid option '--ext')*
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_687580b965708322b9b1dced8a7212d4